### PR TITLE
Json schemas

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint Valid Json
       run: |
-        find quirks/ -name '*.json' -print0 | while IFS= read -r -d '' filename; do 
+        find quirks/ -name '*.json' -print0 -maxdepth 1 | while IFS= read -r -d '' filename; do
           echo "Validating $(basename "$filename")"
           python -mjson.tool "$filename" > /dev/null
         done
@@ -40,3 +40,13 @@ jobs:
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
     - name: Lint Duplicates
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb
+
+  validate-schemas:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v3
+    - name: Install ajv-cli
+      run: npm install -g ajv-cli
+    - name: Validate quirk JSONs against the schemas
+      run: ./tools/validate-json-schemas.sh

--- a/quirks/schemas/change-password-URLs-schema.json
+++ b/quirks/schemas/change-password-URLs-schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}

--- a/quirks/schemas/password-rules-schema.json
+++ b/quirks/schemas/password-rules-schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "password-rules": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "password-rules"
+    ]
+  }
+}

--- a/quirks/schemas/shared-credentials-historical-schema.json
+++ b/quirks/schemas/shared-credentials-historical-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "domain-list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "type": "array",
+  "items": {
+    "oneOf": [
+      {
+        "type": "object",
+        "properties": {
+          "shared": {
+            "$ref": "#/definitions/domain-list"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "shared"
+        ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "from": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "to": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "fromDomainsAreObsoleted": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "from",
+          "to"
+        ]
+      }
+    ]
+  }
+}

--- a/quirks/schemas/shared-credentials-schema.json
+++ b/quirks/schemas/shared-credentials-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "domain-list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "type": "array",
+  "items": {
+    "oneOf": [
+      {
+        "type": "object",
+        "properties": {
+          "shared": {
+            "$ref": "#/definitions/domain-list"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "shared"
+        ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "from": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "to": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "fromDomainsAreObsoleted": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "from",
+          "to"
+        ]
+      }
+    ]
+  }
+}

--- a/quirks/schemas/websites-that-append-2fa-to-password-schema.json
+++ b/quirks/schemas/websites-that-append-2fa-to-password-schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "type": "string"
+  }
+}

--- a/quirks/schemas/websites-with-shared-credential-backends-schema.json
+++ b/quirks/schemas/websites-with-shared-credential-backends-schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "array",
+    "uniqueItems": true,
+    "items": {
+      "type": "string"
+    },
+    "minItems": 1
+  }
+}

--- a/tools/validate-json-schemas.sh
+++ b/tools/validate-json-schemas.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v ajv &> /dev/null
+then
+    echo "The 'ajv' command is required, please install the 'ajv-cli' package"
+    exit 1
+fi
+
+# Finds all JSON files in the quirks directory and validates them against the corresponding schema.
+find quirks -name '*.json' -print0 -maxdepth 1 | while IFS= read -r -d '' filename; do
+    schema="quirks/schemas/$(basename "$filename" .json)-schema.json"
+    echo "Validating $filename against $schema"
+    ajv -s "$schema" -d "$filename" --spec=draft2020
+done


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [ ] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [ ] The top-level JSON objects are sorted alphabetically
- [ ] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
